### PR TITLE
Fix broken link in footer

### DIFF
--- a/app/src/components/DocsFooter.tsx
+++ b/app/src/components/DocsFooter.tsx
@@ -79,7 +79,7 @@ export function DocsFooter({
         </div>
         {config.repo && (
           <Link
-            href={`${config.repo}/edit/${config.branch ?? 'main'}/src/pages${
+            href={`${config.repo}/edit/${config.branch ?? 'main'}${
               current?.meta.source ?? current?.href ?? ''
             }.mdx`}
           >


### PR DESCRIPTION
Fix: resulting link in the footer was broken.

Since `app` directory is a template, this should fix footer link in `radash` docs website as well

Closes #5 

Edit: footer in the demo below seems unchanged. Is there anything else to edit for the URL to change..?