### PR TITLE
Fix broken GitHub edit link

### DIFF
--- a/app/src/components/DocsFooter.tsx
+++ b/app/src/components/DocsFooter.tsx
@@ -79,7 +79,7 @@ export function DocsFooter({
         </div>
         {config.repo && (
           <Link
-            href={`${config.repo}/edit/${config.branch ?? 'main'}/src/pages${
+            href={`${config.repo}/edit/${config.branch ?? 'main'}${
               current?.meta.source ?? current?.href ?? ''
             }.mdx`}
           >


### PR DESCRIPTION
It was pointing at a nonexistent page after the code's folder structure changed.

Fixes #5 